### PR TITLE
Add rfc process docs changes expectations

### DIFF
--- a/rfc/index.md
+++ b/rfc/index.md
@@ -47,7 +47,10 @@ Some changes do not require an RFC:
     invisible to users-of-Tremor.
 
 If you submit a pull request to implement a new feature without going through
-the RFC process, it may be closed with a polite request to submit an RFC first.
+the RFC process, it may be:
+ * Modified to add a `needs-rfc` label by a maintainer. The maintainers will assist with following the RFC process and getting the candidate contribution merged following the RFC process.
+ * Closed with a polite request to submit an RFC first. For significant contributions we will likely request that one of the contributors becomes a maintainer of tremor - the the very least for the contribution.
+ * For large contributions - we recommend engaging with the community and maintainers as early as possible so that we can align the goals of the project and the needs of a specific contribution.
 
 
 ### Sub-team-specific Guidelines
@@ -60,7 +63,7 @@ the Tremor community's [sub-team] specific guidelines for:
  ### - [Library Changes](process/libs_changes)
  ### - [API Changes](process/api_changes)
  ### - [Architecture Changes](process/arch_changes)
-
+### - [Documentation Changes](process/docs_changes)
 
 ## Before Creating an RFC:
 [Before creating an RFC]: #before-creating-an-rfc
@@ -105,7 +108,7 @@ merged into the RFC repository as a markdown file. At that point the RFC is
     revise it in response.
   - Each pull request will be labeled with the most relevant [sub-team], which
     will lead to its being triaged by that team in a future meeting and assigned
-    to a member of the subteam.
+    to a member of the sub-team.
   - Build consensus and integrate feedback. RFCs that have broad support are
     much more likely to make progress than those that don't receive any
     comments. Feel free to reach out to the RFC assignee in particular to get
@@ -119,24 +122,24 @@ merged into the RFC repository as a markdown file. At that point the RFC is
     request, and leave a comment on the pull request explaining your changes.
     Specifically, do not squash or rebase commits after they are visible on the
     pull request.
-  - At some point, a member of the subteam will propose a "motion for final
+  - At some point, a member of the sub-team will propose a "motion for final
     comment period" (FCP), along with a *disposition* for the RFC (merge, close,
     or postpone).
     <!-- alex ignore clearly -->
   - This step is taken when enough of the tradeoffs have been discussed that
-    the subteam is in a position to make a decision. That does not require
+    the sub-team is in a position to make a decision. That does not require
     consensus amongst all participants in the RFC thread (which is usually
     impossible). However, the argument supporting the disposition on the RFC
     needs to have already been clearly articulated, and there should not be a
-    strong consensus *against* that position outside of the subteam. Subteam
+    strong consensus *against* that position outside of the sub-team. Sub-team
     members use their best judgment in taking this step, and the FCP itself
     ensures there is ample time and notification for stakeholders to push back
     if it is made prematurely.
     - For RFCs with lengthy discussion, the motion to FCP is usually preceded by
       a *summary comment* trying to lay out the current state of the discussion
       and major tradeoffs/points of disagreement.
-    - Before actually entering FCP, *all* members of the subteam must sign off;
-    this is often the point at which many subteam members first review the RFC
+    - Before actually entering FCP, *all* members of the sub-team must sign off;
+    this is often the point at which many sub-team members first review the RFC
     in full depth.
   - The FCP lasts ten calendar days, so that it is open for at least 5 business
     days.

--- a/rfc/process/docs_changes.md
+++ b/rfc/process/docs_changes.md
@@ -11,15 +11,13 @@ Any change to tremor that changes a public behaviour, configuration or any other
 
 All maintainers, in all sub-teams will monitor for documentation and content changes and may request changes to contributions - such as the addition of relevant details for complex changes; or, for additional content to be created where new capabilities or features are being added. For example, a new `codec` or `connector` should include examples of how to correctly configure and use them in a canonical example tremor application.
 
-Documentation RFCs are managed by the documentation sub-team, and tagged `docs`. The
-documentation sub-team will do an initial triage of new PRs within a week of
-submission. The result of triage will either be that the PR is assigned to a
-member of the sub-team for shepherding, the PR is closed as postponed because
-the sub-team believe it might be a good idea, but is not currently aligned with
-Tremor's priorities, or the PR is closed because the sub-team feel it should
-not be done and further discussion is not necessary. In the latter two
-cases, the sub-team will give a detailed explanation. We'll follow the standard
-procedure for shepherding, final comment period, etc.
+Documentation RFCs, if they are needed, are managed by the documentation sub-team, and tagged `docs`.
+
+All RFCs are monitored by the documentation sub-team who will do an initial triage of new `needs-rfc` PRs within a week of submission. The result of triage be a decision on the documentation needs for the PR or RFC candidate.
+
+Generally speaking all user facing functions, interactions or behaviors requires
+both reference and practical `how to get jobs done` guides and be accompanied
+with functional tutorials and usage examples.
 
 ## Since
 

--- a/rfc/process/docs_changes.md
+++ b/rfc/process/docs_changes.md
@@ -1,0 +1,26 @@
+---
+title: Documentation Changes
+id: docs_changes
+---
+
+# RFC policy - Documentation design
+
+Any change to tremor that requires an RFC requires complete documentation to be contributed to cover the changes covered by the RFC and any changes to existing capabilities, features or functions within tremor.
+
+Any change to tremor that changes a public behaviour, configuration or any other expectation that a user of the project interacts with should result in documentation being created, changed or removed consistent with the change itself.
+
+All maintainers, in all sub-teams will monitor for documentation and content changes and may request changes to contributions - such as the addition of relevant details for complex changes; or, for additional content to be created where new capabilities or features are being added. For example, a new `codec` or `connector` should include examples of how to correctly configure and use them in a canonical example tremor application.
+
+Documentation RFCs are managed by the documentation sub-team, and tagged `docs`. The
+documentation sub-team will do an initial triage of new PRs within a week of
+submission. The result of triage will either be that the PR is assigned to a
+member of the sub-team for shepherding, the PR is closed as postponed because
+the sub-team believe it might be a good idea, but is not currently aligned with
+Tremor's priorities, or the PR is closed because the sub-team feel it should
+not be done and further discussion is not necessary. In the latter two
+cases, the sub-team will give a detailed explanation. We'll follow the standard
+procedure for shepherding, final comment period, etc.
+
+## Since
+
+This is a new process document since 2023-Sep-22.

--- a/rfc/process/docs_changes.md
+++ b/rfc/process/docs_changes.md
@@ -21,4 +21,4 @@ with functional tutorials and usage examples.
 
 ## Since
 
-This is a new process document since 2023-Sep-22.
+This is a new process document since 2021-Sep-23.

--- a/rfc/process/lang_changes.md
+++ b/rfc/process/lang_changes.md
@@ -37,7 +37,7 @@ be standalone and reference the original, rather than modifying the existing
 RFC. You should add a comment to the original RFC with referencing the new RFC
 as part of the PR.
 
-Obviously, there is some scope for judgment here. As a guideline, if a change
+There is some scope for judgment here. As a guideline, if a change
 affects more than one part of the RFC (i.e., is a non-local change), affects the
 applicability of the RFC to its motivating use cases, or there are multiple
 possible new solutions, then the feature is probably not 'minor' and should get


### PR DESCRIPTION
An attempt to capture the relationship between work requiring RFCs and the
need for all significant changes to tremor to be well documented.

We are currently monitoring this pseudo-informally and tracking as/when needed
but this process should be written down over time.