### PR TITLE
Fix some callouts on artefacts

### DIFF
--- a/docs/artefacts/offramps.md
+++ b/docs/artefacts/offramps.md
@@ -195,7 +195,7 @@ offramp:
 
 The `dns` linked offramp allows performing DNS queries against the system resolver.
 
-::note
+:::note
 No codecs, configuration, or processors are supported.
 :::
 

--- a/docs/artefacts/onramps.md
+++ b/docs/artefacts/onramps.md
@@ -114,9 +114,9 @@ Received messages are immediately acknowledged to the protocol stack. This Onram
 
 ### blaster
 
-!!!note
-
-    This onramp is for benchmarking use, it should not be deployed in a live production system.
+:::note
+This onramp is for benchmarking use, it should not be deployed in a live production system.
+:::
 
 The blaster onramp is built for performance testing, but it can be used for spaced-out replays of events as well. Files to replay can be `xz` compressed. It will keep looping over the file.
 


### PR DESCRIPTION
Two callouts on `onramps` and `offramps` were either not updated or not correctly updated.

Signed-off-by: Sharon Koech <sharonkoech5147@gmail.com>