### PR TITLE
Update Makefile with  `reset` target 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ docs/operations/cli.md: tremor-runtime
 clean:
 	-rm -rf docs/operations/cli.md docs/tremor-script/stdlib
 
+reset: 
+	-rm -rf /node_modules
+	npm install


### PR DESCRIPTION
Following a recent Docusaurus validation error we encountered:

"A validation error occurred.
The validation system was added recently to Docusaurus as an attempt to avoid user configuration errors.
We may have made some mistakes.
If you think your configuration is valid and should keep working, please open a bug report.

ValidationError: Bad navbar item type dropdown",

that was solvable by uninstalling and reinstalling node modules, I have added a rule to the Makefile that automates the process when you run `make reset` on the main branch.

Signed-off-by: Sharon Koech <sharonkoech5147@gmail.com>