### PR TITLE
Publish bench

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -17,6 +17,11 @@ module.exports = {
       dirName: '.'
     },
     {
+      "type": "link",
+      "label": "Benchmarks",
+      "href": "/benchmarks"
+    },
+    {
       type: 'link',
       label: 'API Explorer',
       href: '/api/0',

--- a/src/pages/benchmarks.js
+++ b/src/pages/benchmarks.js
@@ -48,12 +48,19 @@ export default function Home() {
 
     return (
         <Layout
-            title={`Hello from ${siteConfig.title}`}
+            title={`${siteConfig.title}`}
             description="Description will go into a meta tag in <head />">
             <main>
                 <h1 className="text-center font-bold lg:text-5xl text-3xl pb-8 pt-6">
                     Tremor Benchmarks
                 </h1>
+                <p>
+                    Here you can track "live" benchmarks of the tremor runtime for every PR that is
+                    merged into the main branch. The benchmarks are run on the same machine to allow
+                    them to be compared easiley.<br />
+                    This allows comparing and tracking the performance progression of tremor over
+                    time. Clicking on a node will show the related commit hash.
+                </p>
                 <div>{charList}</div>
             </main>
         </Layout>

--- a/versioned_sidebars/version-0.11-sidebars.json
+++ b/versioned_sidebars/version-0.11-sidebars.json
@@ -6,6 +6,11 @@
     },
     {
       "type": "link",
+      "label": "Benchmarks",
+      "href": "/benchmarks"
+    },
+    {
+      "type": "link",
       "label": "API Explorer",
       "href": "/api/0"
     }


### PR DESCRIPTION
This PR makes the `/benchmarks` page publically visible and part of the docs, we can merge it whenever we're happy to make it public.