### PR TITLE
Include usage of `TREMOR_PATH`

### DIFF
--- a/community/development/testing.md
+++ b/community/development/testing.md
@@ -14,7 +14,9 @@ cargo test --all
 cargo run -p tremor-cli -- test all tremor-cli/tests
 ```
 
-_Note: be sure to set a `TREMOR_PATH` before running the commands posted above, without it, some packages will not resolve, and tests may not run. If starting from the root of the tremor-runtime project, use `export TREMOR_PATH="./tremor-script/lib"` in the same terminal before running commands above.._
+:::note
+Be sure to set a `TREMOR_PATH` before running the commands posted above, without it, some packages will not resolve, and tests may not run. If starting from the root of the tremor-runtime project, use `export TREMOR_PATH="./tremor-script/lib"` in the same terminal before running commands above..
+:::
 
 
 ## EQC


### PR DESCRIPTION
When running tests, just a moment ago, I was having difficulty understanding why some path resolution failed. thanks to a [kind contribution](https://discord.com/channels/752801695066488843/752801695066488846/898581689083768883) from `@yatinmaan`, I've decided to add a note for others that may stumble into this same scenario.