### PR TITLE
Update recipe markdown headings to match content

### DIFF
--- a/docs/recipes/04_validate/README.md
+++ b/docs/recipes/04_validate/README.md
@@ -1,4 +1,4 @@
-# Transform
+# Validate
 
 The `validate` example adds the concept of scripts to the trickle file. In this script we validate the schema of the input json against some requirements and only let events through that do satisfy them. Other events are dropped. Those changes are entirely inside the [`example.trickle`](etc/tremor/config/example.trickle).
 

--- a/docs/recipes/10_logstash/README.md
+++ b/docs/recipes/10_logstash/README.md
@@ -1,4 +1,4 @@
-# Transform
+# Logstash
 
 This example shows how handling apache logs with a tremor and elastic search could work. The example is a lot more complex than the initial showcases and combines three components.
 

--- a/docs/recipes/11_influx/README.md
+++ b/docs/recipes/11_influx/README.md
@@ -1,4 +1,4 @@
-# Transform
+# Influx
 
 This example demonstrates using Tremor as a proxy and aggregator for InfluxDB data. As such it coveres three topics. Ingesting and decoding influx data is the first part. Then grouping this data and aggregating over it.
 

--- a/docs/recipes/12_postgres_timescaledb/README.md
+++ b/docs/recipes/12_postgres_timescaledb/README.md
@@ -1,4 +1,4 @@
-# Transform
+# PostgreSQL TimescaleDB
 
 This example demonstrates extracting data from a Postgres database and inserting
 data to TimescaleDB.

--- a/docs/recipes/13_grafana/README.md
+++ b/docs/recipes/13_grafana/README.md
@@ -1,4 +1,4 @@
-# Transform
+# Grafana
 
 This example demonstrates using Tremor as a proxy and aggregator for InfluxDB data. As such it coveres three topics. Ingesting and decoding influx data is the first part. Then grouping this data and aggregating over it.
 

--- a/versioned_docs/version-0.11/recipes/03_validate/README.md
+++ b/versioned_docs/version-0.11/recipes/03_validate/README.md
@@ -1,4 +1,4 @@
-# Transform
+# Validate
 
 The `validate` example adds the concept of scripts to the trickle file. In this script we validate the schema of the input json against some requirements and only let events through that do satisfy them. Other events are dropped. Those changes are entirely inside the [`example.trickle`](etc/tremor/config/example.trickle).
 

--- a/versioned_docs/version-0.11/recipes/10_logstash/README.md
+++ b/versioned_docs/version-0.11/recipes/10_logstash/README.md
@@ -1,4 +1,4 @@
-# Transform
+# Logstash
 
 This example shows how handling apache logs with a tremor and elastic search could work. The example is a lot more complex than the initial showcases and combines three components.
 

--- a/versioned_docs/version-0.11/recipes/11_influx/README.md
+++ b/versioned_docs/version-0.11/recipes/11_influx/README.md
@@ -1,4 +1,4 @@
-# Transform
+# Influx
 
 This example demonstrates using Tremor as a proxy and aggregator for InfluxDB data. As such it coveres three topics. Ingesting and decoding influx data is the first part. Then grouping this data and aggregating over it.
 

--- a/versioned_docs/version-0.11/recipes/12_postgres_timescaledb/README.md
+++ b/versioned_docs/version-0.11/recipes/12_postgres_timescaledb/README.md
@@ -1,4 +1,4 @@
-# Transform
+# PostgreSQL TimescaleDB
 
 This example demonstrates extracting data from a Postgres database and inserting
 data to TimescaleDB.

--- a/versioned_docs/version-0.11/recipes/13_grafana/README.md
+++ b/versioned_docs/version-0.11/recipes/13_grafana/README.md
@@ -1,4 +1,4 @@
-# Transform
+# Grafana
 
 This example demonstrates using Tremor as a proxy and aggregator for InfluxDB data. As such it coveres three topics. Ingesting and decoding influx data is the first part. Then grouping this data and aggregating over it.
 


### PR DESCRIPTION
This patch updates the headings in a few Recipes to match the subject of the pages.