### PR TITLE
fix height property for benchmark charts

### DIFF
--- a/src/components/Benchmark.js
+++ b/src/components/Benchmark.js
@@ -9,9 +9,6 @@ class BenchmarkChart extends Component {
             title: props.title,
             options: {
                 chart: {
-                    width: '100px',
-                    height: 0.5,
-                    parentHeightOffset: 0.5,
                     id: props.title + "-chart",
                     events: {
                         markerClick: (c1, c2, { dataPointIndex }) =>
@@ -66,6 +63,7 @@ class BenchmarkChart extends Component {
             <BrowserOnly>
                 {() => {
                     return (<Chart
+                        height="100%"
                         options={this.state.options}
                         series={this.state.series}
                         type="line"


### PR DESCRIPTION
Per https://github.com/apexcharts/apexcharts.js/issues/1803#issuecomment-665571088

Changes the height to be less crazy. :) 

![Screenshot from 2022-03-23 13-56-12](https://user-images.githubusercontent.com/1394552/159775143-22fab069-dce8-4bc7-96dc-3cb6178bf637.png)


Signed-off-by: Jeffrey Sica <jeef111x@gmail.com>