### PR TITLE
change pwd to PWD

### DIFF
--- a/docs/guides/basics.md
+++ b/docs/guides/basics.md
@@ -335,7 +335,7 @@ end;
 Same as before we can test our code, you can fetch the finished file from [git](__GIT__/../code/basics/transform.troy).
 
 ```bash
-$ TREMOR_PATH="$TREMOR_PATH:${pwd}/transform" tremor run transfor/main.troy
+$ TREMOR_PATH="$TREMOR_PATH:${PWD}/transform" tremor run transform/main.troy
 hello
 Hello.
 why
@@ -437,7 +437,7 @@ end;
 That all set, we can run our script as before, just this time, when entering `exit` tremor will terminate.
 
 ```bash
-$ TREMOR_PATH="$TREMOR_PATH:${pwd}/filter" tremor run filter/main.troy
+$ TREMOR_PATH="$TREMOR_PATH:${PWD}/filter" tremor run filter/main.troy
 hello
 Hello.
 why

--- a/docs/guides/code/basics/transform/lib/scripts.tremor
+++ b/docs/guides/code/basics/transform/lib/scripts.tremor
@@ -10,7 +10,7 @@ script
   # Find the right punctuation by looking at the first wird of the last sentence
   # yes this is a poor heuristic!
   let punctuation = match event of 
-    case ~ re|.*[.?!]?(Why\|How\|Where\|Who)[^.?!]*$| => "?"
+    case ~ re|.*[.?!]?(Why\|How\|Where\|Who\|When)[^.?!]*$| => "?"
     case _ => "."
   end;
   event + punctuation


### PR DESCRIPTION
Fixed command line typo `pwd` to `PWD` in the guides so it works, added 'When' to the punctuation script 