### PR TITLE
Fix backtick typo

### DIFF
--- a/docs/concepts/aggregation.md
+++ b/docs/concepts/aggregation.md
@@ -99,7 +99,7 @@ All the synthetic outputs of successive 5 minute windows that fit into a 15 minu
 into the 15 minute window. All the outputs of successive 15 minute intervals that fit into a 1 hour interval
 are **merged** into the 1 hour window. By chaining and merging, tremor can optimise ( reduce ) the amount
 of memory required across the chain when compared to multiple independent windows `select` expressions.
-In the case of aggregate functions like ` aggr::stats::hdr`` or `aggr::stats::dds``` the savings are significant.
+In the case of aggregate functions like ` aggr::stats::hdr` or `aggr::stats::dds` the savings are significant.
 
 If we imagine 1M events per second, that is 300M events every 5 minutes. 900M every 15, 3.6B every hour.
 


### PR DESCRIPTION
I was checking out the docs for aggregation and found this typo

![image](https://user-images.githubusercontent.com/25647296/193853577-5f4f0d23-49aa-4c9a-8ea8-bd9d46ae7d93.png)


Signed-off-by: Mario Ortiz Manero <marioortizmanero@gmail.com>