### PR TITLE
Fix typos in const section

### DIFF
--- a/versioned_docs/version-0.12/language/expressions.md
+++ b/versioned_docs/version-0.12/language/expressions.md
@@ -369,11 +369,11 @@ Path's in Tremor are themselves expressions in their own right.
 
 ## Const
 
-Const grammer:
+Const grammar:
 
 ![const grammar](./reference/svg/const.svg)
 
-Const can be used to define immutable, constant values that get evaluated at compile time. This is more performant then `let` as all logic can happen at compile time and is helpful for setting up lookup tables or other never changing data structures.
+Const can be used to define immutable, constant values that get evaluated at compile time. This is more performant than `let` as all logic can happen at compile time and is helpful for setting up lookup tables or other never changing data structures.
 
 ## Let
 


### PR DESCRIPTION
Signed-off-by: Mariano Guerra <mariano@marianoguerra.org>

The change in the last line was introduced by github's text editor, don't know what it is, a new line?